### PR TITLE
fix(build): Fix windows environment build issue that pull cbor component fail

### DIFF
--- a/examples/diagnostics_smoke_test/CMakeLists.txt
+++ b/examples/diagnostics_smoke_test/CMakeLists.txt
@@ -12,7 +12,6 @@ if(DEFINED ENV{INSIGHTS_PATH})
 else()
   set(INSIGHTS_PATH ${CMAKE_CURRENT_LIST_DIR}/../..)
 endif(DEFINED ENV{INSIGHTS_PATH})
-list(APPEND EXTRA_COMPONENT_DIRS ${INSIGHTS_PATH}/components)
 
 set(PROJECT_VER "1.0")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/examples/diagnostics_smoke_test/main/idf_component.yml
+++ b/examples/diagnostics_smoke_test/main/idf_component.yml
@@ -2,4 +2,3 @@
 dependencies:
   espressif/esp_insights:
     version: "~1.1.0"
-    override_path: "../../../components/esp_insights"

--- a/examples/minimal_diagnostics/CMakeLists.txt
+++ b/examples/minimal_diagnostics/CMakeLists.txt
@@ -12,7 +12,6 @@ if(DEFINED ENV{INSIGHTS_PATH})
 else()
   set(INSIGHTS_PATH ${CMAKE_CURRENT_LIST_DIR}/../..)
 endif(DEFINED ENV{INSIGHTS_PATH})
-list(APPEND EXTRA_COMPONENT_DIRS ${INSIGHTS_PATH}/components)
 
 set(PROJECT_VER "1.0")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/examples/minimal_diagnostics/main/idf_component.yml
+++ b/examples/minimal_diagnostics/main/idf_component.yml
@@ -2,4 +2,3 @@
 dependencies:
   espressif/esp_insights:
     version: "~1.1.0"
-    override_path: "../../../components/esp_insights"


### PR DESCRIPTION
When use Windows environment and build esp-insghts example, it will build failed that pull cbor component error. So change the yaml file that when build example will pull all  components instead of using the old one.