### PR TITLE
Fix ROData pointers not getting resolved on IDf v5.2 onwards

### DIFF
--- a/components/esp_diag_data_store/idf_component.yml
+++ b/components/esp_diag_data_store/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: Simple APIs to use ESP Diagnostics data storage
 url: https://github.com/espressif/esp-insights/tree/main/components/esp_diag_data_store
 repository: https://github.com/espressif/esp-insights.git

--- a/components/esp_diag_data_store/src/rtc_store/rtc_store.c
+++ b/components/esp_diag_data_store/src/rtc_store/rtc_store.c
@@ -94,7 +94,7 @@ typedef struct {
     rbuf_data_t critical;
     rbuf_data_t non_critical;
     rtc_store_meta_header_t *meta_hdr;
-    char sha_sum[2 * SHA_SIZE + 1];
+    char sha_sum[RTC_STORE_HEX_SHA_SIZE + 1];
 } rtc_store_priv_data_t;
 
 // have a strategy to invalidate data beyond this
@@ -504,6 +504,7 @@ static inline uint8_t to_int_digit(unsigned val)
     return (val <= '9') ? (val - '0') : (val - 'a' + 10);
 }
 
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
 static void hex_to_bytes(uint8_t *src, uint8_t *dst, int out_len)
 {
     for (int i = 0; i < out_len; i++) {
@@ -512,6 +513,7 @@ static void hex_to_bytes(uint8_t *src, uint8_t *dst, int out_len)
         dst[i] = (val0 << 4) | (val1);
     }
 }
+#endif
 
 static esp_err_t rtc_store_meta_hdr_init()
 {
@@ -556,11 +558,12 @@ skip_nvs_read_write:
 
     // populate meta header
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-    esp_app_get_elf_sha256(s_priv_data.sha_sum, sizeof(s_priv_data.sha_sum));
+    const uint8_t* src = esp_app_get_description()->app_elf_sha256;
+    memcpy((uint8_t *)s_priv_data.meta_hdr->sha_sum, src, RTC_STORE_SHA_SIZE);
 #else
     esp_ota_get_app_elf_sha256(s_priv_data.sha_sum, sizeof(s_priv_data.sha_sum));
+    hex_to_bytes((uint8_t *) s_priv_data.sha_sum, (uint8_t *) s_priv_data.meta_hdr->sha_sum, RTC_STORE_SHA_SIZE);
 #endif
-    hex_to_bytes((uint8_t *) s_priv_data.sha_sum, (uint8_t *) s_priv_data.meta_hdr->sha_sum, SHA_SIZE);
 
     s_priv_data.meta_hdr->gen_id = gen_id;
     s_priv_data.meta_hdr->boot_cnt = boot_cnt;

--- a/components/esp_diag_data_store/src/rtc_store/rtc_store.h
+++ b/components/esp_diag_data_store/src/rtc_store/rtc_store.h
@@ -13,7 +13,8 @@
 extern "C" {
 #endif
 
-#define SHA_SIZE  (CONFIG_APP_RETRIEVE_LEN_ELF_SHA / 2)
+#define RTC_STORE_HEX_SHA_SIZE  16                              /* Length of ELF SHA as HEX string*/
+#define RTC_STORE_SHA_SIZE      (RTC_STORE_HEX_SHA_SIZE / 2)    /* Length of ELF SHA as raw bytes*/
 
 /**
  * @brief header record to identify firmware/boot data a record represent
@@ -21,7 +22,7 @@ extern "C" {
 typedef struct {
     uint8_t gen_id;             // generated on each hard reset
     uint8_t boot_cnt;           // updated on each soft reboot
-    char sha_sum[SHA_SIZE];     // elf shasum
+    char sha_sum[RTC_STORE_SHA_SIZE];     // elf shasum
     bool valid;                 //
 } rtc_store_meta_header_t;
 

--- a/components/esp_diagnostics/idf_component.yml
+++ b/components/esp_diagnostics/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.0"
+version: "1.2.1"
 description: Diagnostics component used in ESP Insights, which is a remote diagnostics solution to monitor the health of ESP devices in the field.
 url: https://github.com/espressif/esp-insights/tree/main/components/esp_diagnostics
 repository: https://github.com/espressif/esp-insights.git

--- a/components/esp_diagnostics/include/esp_diagnostics.h
+++ b/components/esp_diagnostics/include/esp_diagnostics.h
@@ -126,13 +126,15 @@ typedef struct {
 /**
  * @brief Device information structure
  */
+#define DIAG_HEX_SHA_SIZE   16                                  /* Length of ELF SHA as HEX string*/
+#define DIAG_SHA_SIZE       (DIAG_HEX_SHA_SIZE / 2)             /* Length of ELF SHA as raw bytes*/
 typedef struct {
     uint32_t chip_model;                                      /*!< Chip model */
     uint32_t chip_rev;                                        /*!< Chip revision */
     uint32_t reset_reason;                                    /*!< Reset reason */
     char app_version[32];                                     /*!< Application version */
     char project_name[32];                                    /*!< Project name */
-    char app_elf_sha256[CONFIG_APP_RETRIEVE_LEN_ELF_SHA + 1]; /*!< SHA256 of application elf */
+    char app_elf_sha256[DIAG_HEX_SHA_SIZE + 1]; /*!< SHA256 of application elf */
 } esp_diag_device_info_t;
 
 /**

--- a/components/esp_diagnostics/src/esp_diagnostics_utils.c
+++ b/components/esp_diagnostics/src/esp_diagnostics_utils.c
@@ -82,7 +82,8 @@ esp_err_t esp_diag_device_info_get(esp_diag_device_info_t *device_info)
     device_info->reset_reason = esp_reset_reason();
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
     app_desc = esp_app_get_description();
-    esp_app_get_elf_sha256(device_info->app_elf_sha256, sizeof(device_info->app_elf_sha256));
+    const uint8_t* src = app_desc->app_elf_sha256;
+    memcpy((uint8_t *)device_info->app_elf_sha256, src, DIAG_SHA_SIZE);
 #else
     app_desc = esp_ota_get_app_description();
     esp_ota_get_app_elf_sha256(device_info->app_elf_sha256, sizeof(device_info->app_elf_sha256));

--- a/components/esp_insights/idf_component.yml
+++ b/components/esp_insights/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.0"
+version: "1.2.1"
 description: Firmware agent for ESP Insights, which is a remote diagnostics solution to monitor the health of ESP devices in the field.
 url: https://github.com/espressif/esp-insights/tree/main/components/esp_insights
 repository: https://github.com/espressif/esp-insights.git

--- a/components/esp_insights/src/esp_insights.c
+++ b/components/esp_insights/src/esp_insights.c
@@ -41,7 +41,6 @@
 #endif
 
 #define INSIGHTS_DEBUG_ENABLED      CONFIG_ESP_INSIGHTS_DEBUG_ENABLED
-#define APP_ELF_SHA256_LEN          (CONFIG_APP_RETRIEVE_LEN_ELF_SHA + 1)
 
 #if CONFIG_ESP_INSIGHTS_CLOUD_POST_MIN_INTERVAL_SEC > CONFIG_ESP_INSIGHTS_CLOUD_POST_MAX_INTERVAL_SEC
 #error "CONFIG_ESP_INSIGHTS_CLOUD_POST_MIN_INTERVAL_SEC must be less than or equal to CONFIG_ESP_INSIGHTS_CLOUD_POST_MAX_INTERVAL_SEC"
@@ -94,7 +93,7 @@ typedef struct {
     int data_msg_id;
     uint32_t data_msg_len;
     SemaphoreHandle_t data_lock;
-    char app_sha256[APP_ELF_SHA256_LEN];
+    char app_sha256[DIAG_HEX_SHA_SIZE + 1];
     bool data_sent;
 #if SEND_INSIGHTS_META
 #if INSIGHTS_CMD_RESP
@@ -924,7 +923,7 @@ esp_err_t esp_insights_enable(esp_insights_config_t *config)
         ESP_LOGE(TAG, "Failed to get device info");
         goto enable_err;
     }
-    memcpy(s_insights_data.app_sha256, device_info.app_elf_sha256, sizeof(s_insights_data.app_sha256));
+    memcpy((uint8_t *) s_insights_data.app_sha256, (uint8_t *) device_info.app_elf_sha256, sizeof(s_insights_data.app_sha256));
     err = esp_event_handler_register(INSIGHTS_EVENT, ESP_EVENT_ANY_ID, insights_event_handler, NULL);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to register event handler for INSIGHTS_EVENTS");

--- a/components/esp_insights/src/esp_insights_cbor_encoder.c
+++ b/components/esp_insights/src/esp_insights_cbor_encoder.c
@@ -196,7 +196,7 @@ static union encode_scratch_buf {
     esp_diag_data_pt_t data_pt;
 #endif
     esp_diag_log_data_t log_data_pt;
-    char sha_sum[2 * SHA_SIZE + 1];
+    char sha_sum[DIAG_HEX_SHA_SIZE + 1];
 } enc_scratch_buf;
 
 static inline uint8_t to_hex_digit(unsigned val)
@@ -204,7 +204,7 @@ static inline uint8_t to_hex_digit(unsigned val)
     return (val < 10) ? ('0' + val) : ('a' + val - 10);
 }
 
-static void bytes_to_hex(uint8_t *src, uint8_t *dst, int in_len)
+void bytes_to_hex(uint8_t *src, uint8_t *dst, int in_len)
 {
     for (int i = 0; i < in_len; i++) {
         dst[2 * i] = to_hex_digit(src[i] >> 4);
@@ -216,7 +216,7 @@ static void bytes_to_hex(uint8_t *src, uint8_t *dst, int in_len)
 static inline void _cbor_encode_meta_hdr(CborEncoder *hdr_map, const rtc_store_meta_header_t *hdr)
 {
     cbor_encode_text_stringz(hdr_map, "sha256");
-    bytes_to_hex((uint8_t *) hdr->sha_sum, (uint8_t *) enc_scratch_buf.sha_sum, SHA_SIZE); // expand uint8 packed data to hex
+    bytes_to_hex((uint8_t *) hdr->sha_sum, (uint8_t *) enc_scratch_buf.sha_sum, DIAG_SHA_SIZE); // expand uint8 packed data to hex
     cbor_encode_text_stringz(hdr_map, enc_scratch_buf.sha_sum);
     cbor_encode_text_stringz(hdr_map, "gen_id");
     cbor_encode_uint(hdr_map, hdr->gen_id);
@@ -684,8 +684,7 @@ void esp_insights_cbor_encode_meta_begin(void *data, size_t data_size, const cha
     cbor_encode_text_stringz(&s_diag_meta_map, version);
 
     cbor_encode_text_stringz(&s_diag_meta_map, "ts");
-    cbor_encode_uint(&s_diag_meta_map, esp_diag_timestamp_get());
-
+    cbor_encode_uint(&s_diag_meta_map, esp_diag_timestamp_get()); 
     cbor_encode_text_stringz(&s_diag_meta_map, "sha256");
     cbor_encode_text_stringz(&s_diag_meta_map, sha256);
 }

--- a/components/esp_insights/src/esp_insights_cbor_encoder.h
+++ b/components/esp_insights/src/esp_insights_cbor_encoder.h
@@ -86,3 +86,7 @@ size_t esp_insights_cbor_encode_conf_meta_end(void *data);
 void esp_insights_cbor_encode_diag_conf_data_begin(void);
 void esp_insights_cbor_encode_diag_conf_data_end(void);
 void esp_insights_cbor_encode_diag_conf_data(void);
+
+/* For converting 8 bytes sha256 to hex form */
+void bytes_to_hex(uint8_t *src, uint8_t *dst, int in_len);
+

--- a/components/esp_insights/src/esp_insights_encoder.c
+++ b/components/esp_insights/src/esp_insights_encoder.c
@@ -61,10 +61,11 @@ size_t esp_insights_encode_meta(uint8_t *out_data, size_t out_data_size, char *s
     if (!out_data || !out_data_size) {
         return 0;
     }
-
+    char sha[DIAG_HEX_SHA_SIZE + 1];
+    bytes_to_hex((uint8_t *) sha256,(uint8_t *) sha, DIAG_SHA_SIZE);
     esp_insights_cbor_encode_meta_begin(out_data + TLV_OFFSET,
                                         out_data_size - TLV_OFFSET,
-                                        INSIGHTS_META_VERSION, sha256);
+                                        INSIGHTS_META_VERSION, sha);
     esp_insights_cbor_encode_meta_data_begin();
     esp_insights_encode_meta_data();
     esp_insights_cbor_encode_meta_data_end();
@@ -91,9 +92,11 @@ size_t esp_insights_encode_conf_meta(uint8_t *out_data, size_t out_data_size, ch
     if (!out_data || !out_data_size) {
         return 0;
     }
+    char sha[DIAG_HEX_SHA_SIZE + 1];
+    bytes_to_hex((uint8_t *) sha256,(uint8_t *) sha, DIAG_SHA_SIZE);
     esp_insights_cbor_encode_meta_begin(out_data + TLV_OFFSET,
                                         out_data_size - TLV_OFFSET,
-                                        INSIGHTS_META_VERSION, sha256);
+                                        INSIGHTS_META_VERSION, sha);
     esp_insights_cbor_encode_conf_meta_data_begin();
     /* TODO: Implement and collect diagnostics specific conf meta */
     // esp_insights_encode_conf_meta_data();


### PR DESCRIPTION
With reference to issue #33 and #45. 

ROData pointers were not getting resolved on IDF v5.2 onwards, as the SHA256 hash being sent from esp and one in the firmware package did not match. This was happening due to ```CONFIG_APP_RETRIEVE_LEN_ELF_SHA``` ( Length of APP ELF SHA stored in RAM ) was changed from 16 to 9 after IDF 5.1.4. 

This PR solves above issue by retrieving SHA using ```esp_app_get_description()->app_elf_sha256 ```rather than depending on IDF function ```esp_app_get_elf_sha256()``` which used CONFIG_APP_RETRIEVE_LEN_ELF_SHA. 

I have tested diagnostics_smoke_test on IDF v5.1 and master, which worked as expected.

@vikramdattu Please review and let me know if any changes are required.