### PR TITLE
Add support for non-WiFi networks

### DIFF
--- a/components/esp_insights/CMakeLists.txt
+++ b/components/esp_insights/CMakeLists.txt
@@ -24,6 +24,10 @@ if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.0")
     list(APPEND priv_req esp_wifi)
 endif()
 
+if(CONFIG_ESP_INSIGHTS_THREAD_ENABLED)
+    list(APPEND priv_req openthread)
+endif()
+
 set(pub_req esp_diagnostics)
 
 idf_component_register(SRCS ${srcs}

--- a/components/esp_insights/Kconfig
+++ b/components/esp_insights/Kconfig
@@ -81,4 +81,11 @@ menu "ESP Insights"
         help
             For users already using older metadata, this provides an option to keep using the same.
             This is important as the new metadata version (1.1), is not backwad compatible.
+    
+    config ESP_INSIGHTS_THREAD_ENABLED
+        bool "Check for Thread networks"
+        default n
+        help
+            For nodes connected to Thread networks, this option must be set to 'yes'.
+            This tells Insights to use the thread network for sending data to cloud.
 endmenu


### PR DESCRIPTION
- Check if connected to non-WiFi (i.e. ethernet and thread) networks
- New menuconfig option to be selected when using thread
- Has not yet been tested

## Description
Insights currently only works on WiFi for sending data, this PR adds checks for ethernet and Thread networks to allow data to be transmitted over them too.

Changes include:-
1. Added separate functions for checking wifi, ethernet, thread connectivity
2. In `is_insights_active`, if any one is active then return true
3. Added a menuconfig option to be set when using Thread

## Related
Fixes https://github.com/espressif/esp-insights/issues/51

## Testing
This hasn't yet been properly tested.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
